### PR TITLE
Kitty theme

### DIFF
--- a/kitty/edo.conf
+++ b/kitty/edo.conf
@@ -2,14 +2,11 @@
 ## license:  MIT
 ## upstream: https://github.com/Tnixc/edo/blob/main/kitty/edo.conf
 
-
-
 # The basic colors
 foreground              #becaf9
-background              #181926
-selection_foreground    #181926
-selection_background    #ffbe91
-
+background              #24273a
+selection_foreground    #ffbe91
+selection_background    #5b6078 
 # Cursor colors
 cursor                  #ffbe91
 cursor_text_color       #181926
@@ -28,16 +25,18 @@ macos_titlebar_color system
 
 # Tab bar colors
 active_tab_foreground   #11111b
-active_tab_background   #c198fd
+active_tab_background   #6ea3fe 
 inactive_tab_foreground #becaf9
-inactive_tab_background #181926
+inactive_tab_background #24273a 
 tab_bar_background      #11111b
 
 # Colors for marks (marked text in the terminal)
 mark1_foreground #181926
 mark1_background #98a4f5
+
 mark2_foreground #181926
 mark2_background #c198fd
+
 mark3_foreground #181926
 mark3_background #5ed2ff
 
@@ -74,3 +73,4 @@ color14 #41ddca
 # white
 color7  #b5c9ff
 color15 #aabbe3
+

--- a/kitty/edo.conf
+++ b/kitty/edo.conf
@@ -1,7 +1,5 @@
 ## name:     edo kitty
-## author:   No0ne003
 ## license:  MIT
-## upstream: https://github.com/catppuccin/kitty/blob/main/themes/mocha.conf
 ## upstream: https://github.com/Tnixc/edo/blob/main/kitty/edo.conf
 
 

--- a/kitty/edo.conf
+++ b/kitty/edo.conf
@@ -1,0 +1,78 @@
+## name:     edo kitty
+## author:   No0ne003
+## license:  MIT
+## upstream: https://github.com/catppuccin/kitty/blob/main/themes/mocha.conf
+## upstream: https://github.com/Tnixc/edo/blob/main/kitty/edo.conf
+
+
+
+# The basic colors
+foreground              #becaf9
+background              #24273a
+selection_foreground    #24273a
+selection_background    #ffbe91
+
+# Cursor colors
+cursor                  #ffbe91
+cursor_text_color       #24273a
+
+# URL underline color when hovering with mouse
+url_color               #ffbe91
+
+# Kitty window border colors
+active_border_color     #98a4f5
+inactive_border_color   #6c7086
+bell_border_color       #e9ad5b
+
+# OS Window titlebar colors
+wayland_titlebar_color system
+macos_titlebar_color system
+
+# Tab bar colors
+active_tab_foreground   #11111b
+active_tab_background   #c198fd
+inactive_tab_foreground #becaf9
+inactive_tab_background #181926
+tab_bar_background      #11111b
+
+# Colors for marks (marked text in the terminal)
+mark1_foreground #24273a
+mark1_background #98a4f5
+mark2_foreground #24273a
+mark2_background #c198fd
+mark3_foreground #24273a
+mark3_background #5ed2ff
+
+# The 16 terminal colors
+
+# black
+color0 #494d64
+color8 #5b6078
+
+# red
+color1 #ff6c8d
+color9 #ff6c8d
+
+# green
+color2  #90d05a
+color10 #90d05a
+
+# yellow
+color3  #e9ad5b
+color11 #e9ad5b
+
+# blue
+color4  #6ea3fe
+color12 #6ea3fe
+
+# magenta
+color5  #f0aadd
+color13 #f0aadd
+
+# cyan
+color6  #41ddca
+color14 #41ddca
+
+# white
+color7  #b5c9ff
+color15 #aabbe3

--- a/kitty/edo.conf
+++ b/kitty/edo.conf
@@ -8,13 +8,13 @@
 
 # The basic colors
 foreground              #becaf9
-background              #24273a
-selection_foreground    #24273a
+background              #181926
+selection_foreground    #181926
 selection_background    #ffbe91
 
 # Cursor colors
 cursor                  #ffbe91
-cursor_text_color       #24273a
+cursor_text_color       #181926
 
 # URL underline color when hovering with mouse
 url_color               #ffbe91
@@ -36,11 +36,11 @@ inactive_tab_background #181926
 tab_bar_background      #11111b
 
 # Colors for marks (marked text in the terminal)
-mark1_foreground #24273a
+mark1_foreground #181926
 mark1_background #98a4f5
-mark2_foreground #24273a
+mark2_foreground #181926
 mark2_background #c198fd
-mark3_foreground #24273a
+mark3_foreground #181926
 mark3_background #5ed2ff
 
 # The 16 terminal colors


### PR DESCRIPTION
## kitty edo theme

![image](https://github.com/user-attachments/assets/25bf80ba-869c-42fe-a075-15323d9cdbdf)


the theme have a background color of #181926 instead of #24273a cuz its darker and looks better. feel free to change it.

> [!NOTE]
> I use catppuccin kitty theme file as a template.